### PR TITLE
Remove invalid include

### DIFF
--- a/Syntaxes/Mathematica.tmLanguage
+++ b/Syntaxes/Mathematica.tmLanguage
@@ -516,10 +516,6 @@
 					<string>$self</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>meta.scope.any.mathematica</string>
-				</dict>
-				<dict>
 					<key>match</key>
 					<string>,</string>
 					<key>name</key>


### PR DESCRIPTION
Not sure what the purpose of this was, but removed as it causes errors to appear in the TextMate logs when parsed.
